### PR TITLE
fix table name in 5_ecto_associations

### DIFF
--- a/phoenix-framework/02-CRUD/guide/5_ecto_associations.md
+++ b/phoenix-framework/02-CRUD/guide/5_ecto_associations.md
@@ -168,7 +168,7 @@ defmodule UserDemo.Repo.Migrations.CreateUsersTasks do
       add :task_id, references(:tasks)
     end
 
-    create unique_index(:user_tasks, [:user_id, :task_id])
+    create unique_index(:users_tasks, [:user_id, :task_id])
   end
 end
 ```


### PR DESCRIPTION
From ":user_tasks" to ":users_tasks". Without this I got an error:
(...) create index user_tasks_user_id_task_id_index
** (MyXQL.Error) (1146) (ER_NO_SUCH_TABLE) Table 'user_demo_dev.user_tasks' doesn't exist